### PR TITLE
Hide private members and special members

### DIFF
--- a/experimental/conf.py
+++ b/experimental/conf.py
@@ -38,6 +38,15 @@ extensions = [
 # Auto API setup
 autoapi_type = 'python'
 autoapi_dirs = [taichi_path, 'src']
+autoapi_options = [
+   'members',
+   'undoc-members',
+#  'private-members',
+   'show-inheritance',
+   'show-module-summary',
+#  'special-members',
+   'imported-members'
+]
 
 # filter out unncessary modules
 autoapi_ignore = [


### PR DESCRIPTION
We don't want to expose APIs starting with `_` and `__`. In this PR I comment out those two kinds of members from the default options.

Reference: https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html#confval-autoapi_options