### PR TITLE
Refine organization of materials

### DIFF
--- a/experimental/_autoapi_templates/index.rst
+++ b/experimental/_autoapi_templates/index.rst
@@ -16,9 +16,11 @@ please refer to `Taichi Docsite <https://docs.taichi.graphics/>`_.
 .. toctree::
    :titlesonly:
 
-   {% for page in pages %}
-   {% if page.top_level_object and page.display %}
-   {{ page.include_path }}
-   {% endif %}
-   {% endfor %}
-
+   taichi/index
+   taichi/ad/index
+   taichi/aot/index
+   taichi/linalg/index
+   taichi/profiler/index
+   taichi/tools/index
+   taichi/types/index
+   taichi/ui/index

--- a/experimental/_autoapi_templates/python/module.rst
+++ b/experimental/_autoapi_templates/python/module.rst
@@ -1,0 +1,81 @@
+{% if not obj.display %}
+:orphan:
+
+{% endif %}
+:py:mod:`{{ obj.name }}`
+=========={{ "=" * obj.name|length }}
+
+.. py:module:: {{ obj.name }}
+
+{% if obj.docstring %}
+.. autoapi-nested-parse::
+
+   {{ obj.docstring|indent(3) }}
+
+{% endif %}
+
+
+{% block content %}
+{% if obj.all is not none %}
+{% set visible_children = obj.children|selectattr("short_name", "in", obj.all)|list %}
+{% elif obj.type is equalto("package") %}
+{% set visible_children = obj.children|selectattr("display")|list %}
+{% else %}
+{% set visible_children = obj.children|selectattr("display")|rejectattr("imported")|list %}
+{% endif %}
+{% if visible_children %}
+
+{% set visible_classes = visible_children|selectattr("type", "equalto", "class")|list %}
+{% set visible_functions = visible_children|selectattr("type", "equalto", "function")|list %}
+{% set visible_attributes = visible_children|selectattr("type", "equalto", "data")|list %}
+{% if "show-module-summary" in autoapi_options and (visible_classes or visible_functions) %}
+{% block classes scoped %}
+{% if visible_classes %}
+Classes
+~~~~~~~
+
+.. autoapisummary::
+
+{% for klass in visible_classes %}
+   {{ klass.id }}
+{% endfor %}
+
+
+{% endif %}
+{% endblock %}
+
+{% block functions scoped %}
+{% if visible_functions %}
+Functions
+~~~~~~~~~
+
+.. autoapisummary::
+
+{% for function in visible_functions %}
+   {{ function.id }}
+{% endfor %}
+
+
+{% endif %}
+{% endblock %}
+
+{% block attributes scoped %}
+{% if visible_attributes %}
+Attributes
+~~~~~~~~~~
+
+.. autoapisummary::
+
+{% for attribute in visible_attributes %}
+   {{ attribute.id }}
+{% endfor %}
+
+
+{% endif %}
+{% endblock %}
+{% endif %}
+{% for obj_item in visible_children %}
+{{ obj_item.render()|indent(0) }}
+{% endfor %}
+{% endif %}
+{% endblock %}

--- a/experimental/conf.py
+++ b/experimental/conf.py
@@ -38,12 +38,13 @@ extensions = [
 # Auto API setup
 autoapi_type = 'python'
 autoapi_dirs = [taichi_path, 'src']
+autoapi_member_order = 'alphabetical'
 autoapi_options = [
    'members',
    'undoc-members',
 #  'private-members',
    'show-inheritance',
-   'show-module-summary',
+#  'show-module-summary',
 #  'special-members',
    'imported-members'
 ]


### PR DESCRIPTION
Related issue = close #9

This PR does the following:
1. Make the index page contain:
- `taichi`
- `taichi.ad`
- `taichi.aot`
- `taichi.linalg`
- `taichi.profiler`
- `taichi.tools`
- `taichi.types`
- `taichi.ui`
2. Keep only actual APIs (no subpackages, summaries, etc.) in each page. This is done by adding a customized version of https://github.com/readthedocs/sphinx-autoapi/blob/master/autoapi/templates/python/module.rst.
3. Make APIs in each page ordered alphabetically.