### PR TITLE
Remove redundant html files

### DIFF
--- a/experimental/conf.py
+++ b/experimental/conf.py
@@ -77,8 +77,19 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-
+exclude_patterns = [
+    '_build', 'Thumbs.db', '.DS_Store',
+    '**/taichi/**/_*',
+    '**/taichi/_*',
+    '**/taichi/lang*',
+    '**/taichi/linalg/cg*',
+    '**/taichi/linalg/sparse_matrix*',
+    '**/taichi/linalg/sparse_solver*',
+    '**/taichi/linalg/taichi_cg*',
+    '**/taichi/math/mathimpl*',
+    '**/taichi/linalg/cg*',
+    '**/taichi/ui/experimental*',
+]
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
This PR removes some redundant html files generated by the docstring-gen process. Not the final version and will be updated in the future.